### PR TITLE
chore(deps): add cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,21 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     directory: /proxy
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
 
   - package-ecosystem: npm
     directory: /app
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
+      semver-major-days: 30


### PR DESCRIPTION
Adds `cooldown` to each Dependabot update entry to avoid PR spam from freshly published versions.

- `default-days: 7` for all ecosystems
- `semver-major-days: 30` for ecosystems that support semver overrides

Security updates bypass the cooldown.